### PR TITLE
Update audio_mixer.cpp audio overflow fixed

### DIFF
--- a/core/mixer/audio/audio_mixer.cpp
+++ b/core/mixer/audio/audio_mixer.cpp
@@ -244,8 +244,12 @@ public:
 
 		audio_buffer result;
 		result.reserve(result_ps.size());
-		boost::range::transform(result_ps, std::back_inserter(result), [](double sample){return static_cast<int32_t>(sample);});		
-		
+		const int32_t min_amplitude = std::numeric_limits<int32_t>::min();
+		const int32_t max_amplitude = std::numeric_limits<int32_t>::max();
+//Modified lambda with proper clipping instead of that horrible overflow (by Chris VDB a.k.a. Elanvrt)
+		boost::range::transform(result_ps, std::back_inserter(result), [&](double sample)
+		{ return static_cast<int32_t>((sample>max_amplitude)?(sample=max_amplitude):(sample<min_amplitude)?(sample=min_amplitude):sample); });		
+
 		const int num_channels = channel_layout_.num_channels;
 		monitor_subject_ << monitor::message("/nb_channels") % num_channels;
 


### PR DESCRIPTION
I finally solved a nasty problem with audio mixing.
When mixing sounds near 0dB, integer overflow occured, a very nasty crackling sound that made our sound engineers go mad at me.
This fix adds proper clipping instead of allowing overflow to happen.
This was already fixed in the 2.1 branch, but I really need this in 2.0.7 because 2.1 is far from production-ready (big audio troubles with Bluefish cards...) I adapted the lambda function in boost::range::transform from there.

Only tested with stereo sounds.

Hope this works, this is my first ever github pull request...
